### PR TITLE
fix empty articleList, articleList will not be null but an empty Arti…

### DIFF
--- a/controllers/oetagsTagController.php
+++ b/controllers/oetagsTagController.php
@@ -88,7 +88,7 @@ class oetagsTagController extends \AList
         $oArticleList = $this->getArticleList();
 
         // if tags are off or no articles - showing 404 header (#2139)
-        if (!$this->getViewConfig()->showTags($this) || !$oArticleList) {
+        if (!$this->getViewConfig()->showTags($this) || !$oArticleList || count($oArticleList) <= 0) {
             error_404_handler();
         }
 


### PR DESCRIPTION
fix empty articleList, articleList will not be null but an empty ArticleList

This bug allows writing any tag url to the SeoUrls table.
We found a lot of hack attempts as URLs int he SeoUrls table.
Like: tag/coolproduct1111111111111-union-select-char-45-120-49-45-81-45/order-by-as-oxid/
@kermie i think this an urgent fix